### PR TITLE
Use correct index for FeePayingAsset (scale codec)

### DIFF
--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -30,10 +30,14 @@ export const options = (opts: ZeitgeistApiOptions): ApiOptions => {
       zeitgeist: {
         FeePayingAsset: {
           _enum: {
+            ScaleIndexPlaceHolder0: null,
+            ScaleIndexPlaceHolder1: null,
+            ScaleIndexPlaceHolder2: null,
+            ScaleIndexPlaceHolder3: null,
+            ScaleIndexPlaceHolder4: null,
             ForeignAsset: 'u32',
+            ScaleIndexPlaceHolder6: null,
             CampaignAsset: 'Compact<u128>',
-            CustomAsset: 'Compact<u128>',
-            Ztg: null,
           },
         },
         TAssetConversion: 'Option<FeePayingAsset>',


### PR DESCRIPTION
### What does it do?
It modifies the ordering of `FeePayingAsset` by adding dummy values. This is necessary because the scale codec encodes the enum position and the following values for the associated type in that position, which on the other end the chain tries to map to the fee payment asset enum. If those indices don't match, the mapping will fail and in the worst case even potentially silently fail by using another asset to pay the fees.
Furthermore, this PR removes the asset types that cannot be used to pay fees.

You can see a successful fee payment with foreign assets on battery station at [block 5,030,146](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fbsr.zeitgeist.pm#/explorer/query/0xa45fa2d2371f9d279a233dc16e94d6dcc684a5f49f91b05dd53ed791cb1e509d) and at with campaign assets at block 50,030,180.

### What important points should reviewers know?
- The enum positions should always map to those within the [`Assets`](https://github.com/zeitgeistpm/zeitgeist/blob/7000c0d6373087cb209fe628f9ae01e91edf22e7/primitives/src/assets/all_assets.rs#L56-L81) enum (specified by `#[codec(index = x)]`) in the Zeitgeist repository

### Is there something left for follow-up PRs?
- Potentially finding a cleaner solution that results in the index `0x05` for `ForeignAsset` and `0x07` for `CampaignAsset` without using `ScaleIndexPlaceHolder`.

### What alternative implementations were considered?

### Are there relevant PRs or issues?

### References
- [Scale Codec example for Enumerations](https://docs.substrate.io/reference/scale-codec/)